### PR TITLE
Fix #14. Also make it faster

### DIFF
--- a/benchmark.clj
+++ b/benchmark.clj
@@ -26,6 +26,27 @@
                         :best-friend {:person/id 123}}])))
 
 
+(c/quick-bench
+ (p/db [{:person/id 123
+         :person/name "Will"
+         :contact {:phone "000-000-0001"}
+         :best-friend
+         {:person/id 456
+          :person/name "Jose"
+          :account/email "asdf@jkl"}
+         :friends
+         [{:person/id 9001
+           :person/name "Georgia"}
+          {:person/id 456
+           :person/name "Jose"}
+          {:person/id 789
+           :person/name "Frank"}
+          {:person/id 1000
+           :person/name "Robert"}]}
+        {:person/id 456
+         :best-friend {:person/id 123}}]))
+
+
 (def big-data
   [{:foo/data
    (vec

--- a/project.clj
+++ b/project.clj
@@ -5,8 +5,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :source-paths ["src"]
-  :dependencies [[edn-query-language/eql "1.0.1"]
-                 [fast-zip/fast-zip "0.7.0"]]
+  :dependencies [[edn-query-language/eql "1.0.1"]]
   :deploy-repositories [["snapshots" {:sign-releases false
                                       :url "https://clojars.org"
                                       :creds :gpg}]])

--- a/test/pyramid/core_test.cljc
+++ b/test/pyramid/core_test.cljc
@@ -39,10 +39,10 @@
   (t/is (= {:a/id {1 {:a/id 1
                       :b [{:c [:d/id 1]}]}}
             :d/id {1 {:d/id 1
-                      :d/text "a"}}}
+                      :d/txt "a"}}}
            (p/db [{:a/id 1
-                 :b [{:c {:d/id 1
-                          :d/txt "a"}}]}]))
+                   :b [{:c {:d/id 1
+                            :d/txt "a"}}]}]))
         "Collections of non-entities still get normalized")
   (t/is (= {:person/id
             {123


### PR DESCRIPTION
Fixes #14, as well as makes normalizing and adding data to a map twice as fast than before according to my basic benchmarks. 😄 

The tradeoff is that normalizing now uses function recursion, which means we allocate closures on the stack every iteration and are limited by the stack size, whereas before we used a loop/recur which allowed "unlimited" depth.

I tried using [fast-zip](https://github.com/akhudek/fast-zip) to do this in a tail recursive/"stackless" fashion, however it was about 15% to 30% slower in my basic benchmarking and less deterministic (probably due to GC).

I would like to verify this in our production uses to see if we run into any cases where we blow the stack. If it seems fine given reasonable data sizes, I may in the future provide additional functions for normalizing that aren't limited by the stack size to accommodate huge trees of data being added at once.