### PR TITLE
Trampoline

### DIFF
--- a/benchmark.clj
+++ b/benchmark.clj
@@ -85,38 +85,27 @@
 
 
 ;; testing out different trampoline strategies
-(defn create [k i]
-  (if (zero? i)
-    (k)
-    (fn []
-      (create
-       (fn []
-         {:id i
-          :child (k)})
-       (dec i)))))
+(defn create [k depth]
+  (if (zero? depth)
+    (k {:id depth})
+    #(create
+      (fn [c]
+        (fn [] (k {:id depth :child c})))
+      (dec depth))))
 
 
 (def really-nested-data
-  {:foo (trampoline create (constantly {:id 0}) 50000) })
+  {:foo (trampoline create identity 50000) })
+
+
+(update-in really-nested-data
+           [:foo :child :child :child :child]
+           dissoc :child)
+;; => {:foo {:id 50000, :child {:id 49999, :child {:id 49998, :child {:id 49997, :child {:id 49996}}}}}}
 
 
 (do (p/db [really-nested-data])
     nil)
 
+(c/quick-bench (p/db [really-nested-data]))
 
-(defn create2 [k i]
-  (if (pos? i)
-    (fn []
-      (k (create2
-          (fn [c]
-            {:id i
-             :child (c)})
-          (dec i))))
-    (constantly {:id i})))
-
-
-(do (trampoline
-     create2
-     (fn [c] {:id 5 :child (c)})
-     49200)
-    nil)

--- a/benchmark.clj
+++ b/benchmark.clj
@@ -5,6 +5,9 @@
    [clj-async-profiler.core :as prof]))
 
 
+(prof/serve-files 8080)
+
+
 (prof/profile (dotimes [i 10000]
                 (p/db [{:person/id 123
                         :person/name "Will"
@@ -109,3 +112,6 @@
 
 (c/quick-bench (p/db [really-nested-data]))
 
+
+(prof/profile (dotimes [i 1000]
+                (p/db [really-nested-data])))

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {edn-query-language/eql {:mvn/version "1.0.1"}
-        town.lilac/cascade {:local/root "../cascade"}}
+        town.lilac/cascade {:mvn/version "1.1.0"}}
  :aliases {:test
            {:extra-paths ["test"]
             :extra-deps

--- a/deps.edn
+++ b/deps.edn
@@ -1,6 +1,6 @@
 {:paths ["src"]
  :deps {edn-query-language/eql {:mvn/version "1.0.1"}
-        town.lilac/cascade {:mvn/version "1.1.0"}}
+        town.lilac/cascade {:mvn/version "1.1.1"}}
  :aliases {:test
            {:extra-paths ["test"]
             :extra-deps

--- a/deps.edn
+++ b/deps.edn
@@ -1,5 +1,6 @@
 {:paths ["src"]
- :deps {edn-query-language/eql {:mvn/version "1.0.1"}}
+ :deps {edn-query-language/eql {:mvn/version "1.0.1"}
+        town.lilac/cascade {:local/root "../cascade"}}
  :aliases {:test
            {:extra-paths ["test"]
             :extra-deps

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,44 @@
 {
-  "name": "autonormal",
+  "name": "pyramid",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "pyramid",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "ws": "^7.3.1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    }
+  },
   "dependencies": {
     "ws": {
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.3.1.tgz",
-      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA=="
+      "integrity": "sha512-D3RuNkynyHmEJIpD2qrgVkc9DQ23OrN/moAwZX4L8DfvszsJxpjQuUq3LMx6HoYji9fbIOBY18XWBsAux1ZZUA==",
+      "requires": {}
     }
   }
 }

--- a/project.clj
+++ b/project.clj
@@ -5,7 +5,8 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :source-paths ["src"]
-  :dependencies [[edn-query-language/eql "1.0.1"]]
+  :dependencies [[edn-query-language/eql "1.0.1"]
+                 [town.lilac/cascade "1.1.0"]]
   :deploy-repositories [["snapshots" {:sign-releases false
                                       :url "https://clojars.org"
                                       :creds :gpg}]])

--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
             :url "http://www.eclipse.org/legal/epl-v20.html"}
   :source-paths ["src"]
   :dependencies [[edn-query-language/eql "1.0.1"]
-                 [town.lilac/cascade "1.1.0"]]
+                 [town.lilac/cascade "1.1.1"]]
   :deploy-repositories [["snapshots" {:sign-releases false
                                       :url "https://clojars.org"
                                       :creds :gpg}]])

--- a/src/pyramid/core.cljc
+++ b/src/pyramid/core.cljc
@@ -86,13 +86,13 @@
 
 
 (defn- merge-entity
-  [e #?(:clj ^clojure.lang.IKVReduce m :cljs m)]
+  [e #?(:clj ^clojure.lang.IKVReduce m :cljs ^IKVReduce m)]
   (if (nil? e)
     m
     (if (nil? m)
       e
       #?(:clj (.kvreduce m fast-assoc e)
-         :cljs (reduce m assoc e)))))
+         :cljs (-kv-reduce m assoc e)))))
 
 
 (defn add-report

--- a/src/pyramid/core.cljc
+++ b/src/pyramid/core.cljc
@@ -71,20 +71,23 @@
                          lookup-ref)
                        x)
                      x))
-        data' #_(trampoline
+        data' (trampoline
                w/walk
                (fn inner [k x]
                  (if (map-entry? x)
                    ;; skip processing map keys
                    (w/walk
                     inner
-                    k
-                    x)
-                   ;; regular c/postwalk
+                    (fn outer-map-entry
+                      [v]
+                      (k (map-entry
+                          (key x)
+                          (process! v))))
+                    (val x))
+                     ;; regular c/postwalk
                    (w/walk inner (comp k process!) x)))
                process!
-               data)
-        (w/postwalk process! data)]
+               data)]
     {:entities (persistent! @*entities)
      :db (if (entity-map? identify data)
            @*db

--- a/src/pyramid/core.cljc
+++ b/src/pyramid/core.cljc
@@ -95,8 +95,10 @@
          :cljs (-kv-reduce m assoc e)))))
 
 
-(defn add-report-thunkable
-  "Takes a normalized map `db` and some new `data`.
+(defn add-report*
+  "For normal usage, see `pyramid.core/add-report`.
+
+  Takes a normalized map `db` and some new `data`.
   Returns a 0-arity function (thunk) which, when called, will return either
   another thunk or a map containing the keys:
   - :db - the data normalized and merged into `db`
@@ -150,7 +152,7 @@
    :db - the data normalized and merged into `db`.
    :entities - a set of entities found in `data`"
   [db data]
-  (trampoline add-report-thunkable db data))
+  (trampoline add-report* db data))
 
 
 #_(add-report

--- a/test/pyramid/core_test.cljc
+++ b/test/pyramid/core_test.cljc
@@ -549,3 +549,6 @@
            (p/data->query {:a [{:b 42} {:c :d}]})))
   (t/is (= [{[:a 42] [:b]}]
            (p/data->query {[:a 42] {:b 33}}))))
+
+(comment
+  (t/run-tests))


### PR DESCRIPTION
Building off of https://github.com/lilactown/pyramid/pull/15, this PR rewrites the essential algorithm to use continuation-passing style and trampoline in order to avoid using the call stack.

On my personal laptop, this results in slighty slower runtime than the one in #15 using the callstack, but descends over 40,000 before overflowing vs a measly ~3,000, and is still faster than the broken version in the `main` branch.