### PR TITLE
Prevent normalization of records

### DIFF
--- a/src/pyramid/core.cljc
+++ b/src/pyramid/core.cljc
@@ -53,6 +53,7 @@
 (defn- replace-all-nested-entities
   [identify v]
   (cond
+    ;; Don't normalize records
     (record? v) v
 
     (entity-map? identify v)
@@ -89,6 +90,9 @@
        (assoc data k (replace-all-nested-entities identify v))
        ;; add potential entity v to the queue
        (cond
+         ;; Don't normalize records
+         (record? v) queued
+
          (map? v)
          (conj queued v)
 

--- a/src/pyramid/core.cljc
+++ b/src/pyramid/core.cljc
@@ -53,6 +53,8 @@
 (defn- replace-all-nested-entities
   [identify v]
   (cond
+    (record? v) v
+
     (entity-map? identify v)
     (lookup-ref-of identify v)
 

--- a/test/pyramid/core_test.cljc
+++ b/test/pyramid/core_test.cljc
@@ -4,6 +4,11 @@
    [pyramid.ident :as ident]
    [clojure.test :as t]))
 
+(defrecord TestFruitRecord [id name])
+
+(def test-banana
+  (TestFruitRecord. 100 "Banana"))
+
 
 (t/deftest normalization
   (t/is (= {:person/id {0 {:person/id 0}}}
@@ -36,6 +41,11 @@
                    :some-data {1 "hello"
                                3 "world"}}]))
         "Map with numbers as keys")
+  (t/is (= {:person/id {0 {:person/id 0
+                           :some-record test-banana}}}
+           (p/db [{:person/id 0
+                   :some-record test-banana}]))
+        "Map with record as value")
   (t/is (= {:a/id {1 {:a/id 1
                       :b [{:c [:d/id 1]}]}}
             :d/id {1 {:d/id 1


### PR DESCRIPTION
Records behave both like maps and collections, but should probably be treated as opaque by Pyramid.

This prevents,

```clojure 
(pyramid/db [{:my/id  "hello"
              :a-uri  (lambdaisland.uri/uri "http://www.example.com")}])
```

from turning into,

```clojure 
{:my/id {"hello" {:my/id "hello",
                  :a-uri ([:fragment nil]
                          [:query nil]
                          [:path nil]
                          [:port nil]
                          [:host "www.example.com"]
                          [:password nil]
                          [:user nil]
                          [:scheme "http"])}}}
```

And instead returns,

```clojure
{:my/id {"hello" {:my/id "hello"
                  :a-uri #lambdaisland/uri "http://www.example.com"}}}
```

This is in reference to https://github.com/lilactown/pyramid/issues/17.
